### PR TITLE
Fixed missing --no-create arg parsing

### DIFF
--- a/admin/create-repository.py
+++ b/admin/create-repository.py
@@ -79,6 +79,7 @@ class ILDAnaSoftAdmin(object):
     self.printLevel = _parsePrintLevel( parsed.printLevel )
     logging.basicConfig( level=self.printLevel, format='%(levelname)-5s - %(name)-8s: %(message)s' )
 
+    self.noCreate = parsed.noCreate
     self.user = parsed.user
     self.description = parsed.description
     self.benchmark = parsed.benchmark


### PR DESCRIPTION

Fixed missing `--no-create` arg parsing, causing to always trying to create the repository even if `--no-create` arg is specified